### PR TITLE
refactor: clean up unused import and centralize utils

### DIFF
--- a/src/prompts/prompt_manager.py
+++ b/src/prompts/prompt_manager.py
@@ -1,5 +1,4 @@
 import json
-from src.utils import convert_2d_list_to_string
 from src.schemas import ARCPair
 from typing import List
 

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,5 @@
+from .task_utils import *
+from .parsing import *
+from .validate_data import *
+from .submission_exists import *
+from .generate_tasks_list import *


### PR DESCRIPTION
refactor: clean up unused import and centralize utils

- Removed unused `convert_2d_list_to_string` import from `prompt_manager.py`.
- Created `__init__.py` in `utils` to centralize utility imports.
- Included multiple utility modules for easier access across the codebase.